### PR TITLE
Context was not being cleard

### DIFF
--- a/pat.go
+++ b/pat.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/gorilla/context"
 	"github.com/gorilla/mux"
 )
 
@@ -70,6 +71,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 		handler = r.NotFoundHandler
 	}
+	defer context.Clear(req)
 	handler.ServeHTTP(w, req)
 }
 


### PR DESCRIPTION
I was using pat along with gorilla/sessions.

By default, gorilla/mux will clear the context after a request, however gorilla/pat does not have the same behaviour.

This was causing a memory leak in my application and was confusing as I would expect gorilla/pat to be a drop in replacement for gorilla/mux

Cheers
Ryan
