### PR TITLE
KeepContext respected

### DIFF
--- a/pat.go
+++ b/pat.go
@@ -71,7 +71,9 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 		handler = r.NotFoundHandler
 	}
-	defer context.Clear(req)
+	if !r.KeepContext {
+		defer context.Clear(req)
+	}
 	handler.ServeHTTP(w, req)
 }
 


### PR DESCRIPTION
If `KeepContext` is set to `true` the `context` won't be `.Clear()`'ed. fixes #5 