### PR TITLE
[build] Require >= Go 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ sudo: false
 
 matrix:
   include:
-    - go: 1.3
-    - go: 1.4
     - go: 1.5
     - go: 1.6
+    - go: 1.7
+    - go: 1.8
+    - go: 1.9
     - go: tip
   allow_failures:
     - go: tip


### PR DESCRIPTION
pat requires mux, and mux requires Go 1.5. pat thus now also requires Go 1.5.

Addresses #17 