### PR TITLE
Escape backslashes when redirecting

### DIFF
--- a/pat.go
+++ b/pat.go
@@ -70,7 +70,7 @@ func (r *Router) Patch(pat string, h http.HandlerFunc) *mux.Route {
 func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// Clean path to canonical form and redirect.
 	if p := cleanPath(req.URL.Path); p != req.URL.Path {
-		w.Header().Set("Location", p)
+		w.Header().Set("Location", strings.Replace(p, "\\", "%5c", -1))
 		w.WriteHeader(http.StatusMovedPermanently)
 		return
 	}


### PR DESCRIPTION
According to the URL spec (https://url.spec.whatwg.org/), a backslash is
forbidden in a URL and must be escaped. This is especially important
because browsers implement the HTML5-defined anomaly that backslashes
should be interpreted as forward slashes.

The original behaviour allows for an open redirect in pat when ServeHTTP
is used. By escaping the backslash, we can avoid this.