### PR TITLE
Remove documentation loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
 [![sourcegraph](https://sourcegraph.com/github.com/gorilla/pat/-/badge.svg)](https://sourcegraph.com/github.com/gorilla/pat?badge)
 
 ![Gorilla Logo](https://github.com/gorilla/.github/assets/53367916/d92caabf-98e0-473e-bfbf-ab554ba435e5)
-### How to use?
-
-pat is pretty simple. The documentation lives [here](http://www.gorillatoolkit.org/pkg/pat).
 
 ### Install
 With a properly configured Go toolchain:
@@ -65,7 +62,8 @@ func main() {
 }
 ```
 Notice how the routes descend? That's because Pat will take the first route
-that matches. For your own testing, take the line ```router.Get("/",
+that matches.  
+For your own testing, take the line ```router.Get("/",
 homeHandler)``` and put it above the other routes and run the example. When you
-try to curl any of the routes, you'll only get what the homeHandler returns.
+try to curl any of the routes, you'll only get what the homeHandler returns.  
 Design your routes carefully.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description

In https://github.com/gorilla/pat#how-to-use we share a link for documentation, which takes us to https://gorilla.github.io/. And when we click on “Learn more” for gorilla/pat it takes us back to the GitHub repo for gorilla/pat. 
I think this repetition doesn’t make much sense when we are landing on the same page again.

## Run verifications and test

- [x] `make verify` is passing
- [x] `make test` is passing
