### PR TITLE
Call mux.NewRouter() in pat.New()

### DIFF
--- a/pat.go
+++ b/pat.go
@@ -16,7 +16,9 @@ import (
 
 // New returns a new router.
 func New() *Router {
-	return &Router{}
+	return &Router{
+		Router: *mux.NewRouter(),
+	}
 }
 
 // Router is a request router that implements a pat-like API.

--- a/pat_test.go
+++ b/pat_test.go
@@ -62,3 +62,21 @@ func TestPatMatch(t *testing.T) {
 	testMatch(t, "GET", "/foo/x{name}", "/foo/xbar/baz", true, map[string]string{":name": "bar"})
 	testMatch(t, "PATCH", "/foo/x{name}", "/foo/xbar/baz", true, map[string]string{":name": "bar"})
 }
+
+func TestNamedRoutes(t *testing.T) {
+	router := New()
+	route := router.Get("/", nil)
+	name := "foo"
+	route.Name(name)
+	if route.GetError() != nil {
+		t.Errorf("Route name assign: %v", route.GetError())
+	}
+	gotRoute := router.Router.Get(name)
+	if gotRoute == nil {
+		t.Errorf("mux.Router.Get by name returned nil")
+	}
+	gotName := gotRoute.GetName()
+	if gotName != name {
+		t.Errorf("Unexpected route name: got=%q, want=%q", gotName, name)
+	}
+}


### PR DESCRIPTION
Initializing mux.Router with a zero value breaks route naming: the `mux.Router.namedRoutes` map remains nil and an attempt to assign a route name panics.

This fix simply delegates mux.Router creation to its constructor, which does the right thing.